### PR TITLE
More Tablet Progress

### DIFF
--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -45,8 +45,8 @@ public class WMiniShard extends WWidget {
 			//Maybe draw a teeny tiny icon
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();
-				context.getMatrices().translate(6, 6, 0);
-				context.getMatrices().scale(1/3f, 1/3f, 1); // 18px -> 6px or 16px -> 5.33px
+				context.getMatrices().translate(x + 3, y + 3, 0);
+				context.getMatrices().scale(0.375f, 0.375f, 1); // 16px -> 6px
 				RenderSystem.enableDepthTest();
 				context.drawItemWithoutEntity(it, 0, 0);
 				context.getMatrices().pop();

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardSetPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardSetPanel.java
@@ -7,6 +7,7 @@ import io.github.cottonmc.cotton.gui.widget.WLabel;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.modfest.scatteredshards.api.shard.Shard;
+import net.modfest.scatteredshards.client.screen.widget.scalable.WScaledLabel;
 import net.modfest.scatteredshards.component.ShardCollectionComponent;
 import net.modfest.scatteredshards.component.ShardLibraryComponent;
 
@@ -21,7 +22,9 @@ public class WShardSetPanel extends WPanelWithInsets {
 	
 	protected Consumer<Shard> shardConsumer = (it) -> {};
 	
-	private WLabel sourceLabel = new WLabel(Text.literal(""));
+	private WScaledLabel sourceLabel = new WScaledLabel(Text.literal(""), 0.8f)
+			.setColor(0xFF_CCFFCC)
+			.setShadow(true);
 	private List<WMiniShard> shards = new ArrayList<>();
 	public WShardSetPanel() {
 		this.setInsets(new Insets(2));
@@ -57,11 +60,12 @@ public class WShardSetPanel extends WPanelWithInsets {
 		//Start fresh on this panel's actual children
 		this.children.clear();
 		this.add(sourceLabel, 0, 100, 18);
+		sourceLabel.setLocation(0+this.insets.left(), 2+this.insets.top());
 		sourceLabel.setText(Shard.getSourceForSourceId(set));
 		
-		//The actual remaining layout width is less the label and the half-card hanging off the left and right sides
-		int spaceRemaining = layoutWidth() - 100 - MINI_SHARD_HALFWIDTH - MINI_SHARD_HALFWIDTH;
-		int spacePerShard = spaceRemaining - children.size();
+		//The actual remaining layout width is less the label and the width of the card itself
+		int spaceRemaining = layoutWidth() - 100 - MINI_SHARD_WIDTH;
+		int spacePerShard = spaceRemaining / shardSet.size();
 		int xofs = 100;
 		
 		for(int i=0; i<Math.min(shards.size(), shardSet.size()); i++) {


### PR DESCRIPTION
This one's a tight diff so it should be able to just fast-forward on top of other work.

- Adds a WListPanel to the tablet view so all shardSets are displayed and can scroll
- Fixes a bug where block/item icons didn't show up on the face of mini-shards
- Fixes a bug where multiple shards within a shardSet were layed out really weirdly because of negative layout widths and some strange math
- Slightly reduces the size of shard origin labels in hopes of them fitting