### PR TITLE
Don't use world time for BE animations

### DIFF
--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
@@ -14,16 +14,21 @@ import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.networking.ScatteredShardsNetworking;
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.qsl.base.api.entrypoint.client.ClientModInitializer;
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents;
 
 public class ScatteredShardsClient implements ClientModInitializer {
 
 	public static final String SHARD_MODIFY_TOAST_KEY = "toast.scattered_shards.shard_mod";
+
+	public static int animationTickCounter = 0;
 
 	@Override
 	public void onInitializeClient(ModContainer mod) {
 		ClientShardCommand.register();
 		ScatteredShardsNetworking.registerClient();
 		ScatteredShardsContent.registerClient();
+
+		ClientTickEvents.END.register(client -> animationTickCounter++);
 	}
 
 	@SuppressWarnings("resource")

--- a/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
@@ -1,6 +1,7 @@
 package net.modfest.scatteredshards.client.render;
 
 import net.modfest.scatteredshards.api.shard.ShardType;
+import net.modfest.scatteredshards.client.ScatteredShardsClient;
 import org.quiltmc.loader.api.minecraft.ClientOnly;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -40,7 +41,7 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 
 		ShardType shardType = shard.getShardType();
 
-		float l = (entity.getWorld().getTime() + tickDelta) / TICKS_PER_RADIAN;
+		float l = (ScatteredShardsClient.animationTickCounter + tickDelta) / TICKS_PER_RADIAN;
 		l %= Math.PI*2;
 		float angle = l; //(float) (Math.PI/8);
 		Quaternionf rot = new Quaternionf(new AxisAngle4f(angle, 0f, 1f, 0f));


### PR DESCRIPTION
This fixes jitteriness on servers with low ping/tps

The value isn't incremented in the render method because that's called per frame, not per tick.