### PR TITLE
Add shard collection keybind

### DIFF
--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
@@ -28,6 +28,7 @@ public class ScatteredShardsClient implements ClientModInitializer {
 		ClientShardCommand.register();
 		ScatteredShardsNetworking.registerClient();
 		ScatteredShardsContent.registerClient();
+		ScatteredShardsKeybindings.registerClient();
 	}
 
 	@SuppressWarnings("resource")

--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsKeybindings.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsKeybindings.java
@@ -1,0 +1,32 @@
+package net.modfest.scatteredshards.client;
+
+import com.mojang.blaze3d.platform.InputUtil;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.minecraft.client.option.KeyBind;
+import net.modfest.scatteredshards.client.screen.ShardTabletGuiDescription;
+import net.modfest.scatteredshards.component.ScatteredShardsComponents;
+import org.lwjgl.glfw.GLFW;
+import org.quiltmc.loader.api.minecraft.ClientOnly;
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents;
+
+public class ScatteredShardsKeybindings {
+	public static KeyBind shardsKeyBind = KeyBindingHelper.registerKeyBinding(new KeyBind(
+			"key.scattered_shards.shards",
+			InputUtil.Type.KEYSYM,
+			GLFW.GLFW_KEY_J,
+			"category.scattered_shards.scattered_shards"
+	));
+
+	@ClientOnly
+	public static void registerClient() {
+		ClientTickEvents.END.register(client -> {
+			while (shardsKeyBind.wasPressed()) {
+				if (client.player != null && client.world != null) {
+					var collection = ScatteredShardsComponents.getShardCollection(client.player);
+					var library = ScatteredShardsComponents.getShardLibrary(client.world);
+					client.execute(() -> client.setScreen(new ShardTabletGuiDescription.Screen(collection, library)));
+				}
+			}
+		});
+	}
+}

--- a/src/main/resources/assets/scattered_shards/lang/en_us.json
+++ b/src/main/resources/assets/scattered_shards/lang/en_us.json
@@ -36,5 +36,7 @@
   "toast.scattered_shards.shard_mod.fail": "Failed to modify '%s'",
   "block.scattered_shards.shard_block": "Shard",
   "block.scattered_shards.shard_block.pickup_fail": "Shard already collected!",
-  "item.scattered_shards.shard_tablet": "Shard Tablet"
+  "item.scattered_shards.shard_tablet": "Shard Tablet",
+  "category.scattered_shards.scattered_shards": "Scattered Shards",
+  "key.scattered_shards.shards": "Open Shard Collection"
 }


### PR DESCRIPTION
Extrmely basic keybind that just copies what `/shards` does. can update to match #18 if needed.

tldr:
![image](https://github.com/ModFest/scattered-shards/assets/55819817/e717e027-7dbb-4138-99e1-cef4909e22f6)
