### PR TITLE
Add data for shard icons and menu colors + improve permissions

### DIFF
--- a/src/main/java/net/modfest/scatteredshards/api/ShardDisplaySettings.java
+++ b/src/main/java/net/modfest/scatteredshards/api/ShardDisplaySettings.java
@@ -1,0 +1,70 @@
+package net.modfest.scatteredshards.api;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.modfest.scatteredshards.api.impl.ColorCodec;
+
+public class ShardDisplaySettings {
+	private boolean drawMiniIcons;
+	private int libraryColor;
+	private int viewerTopColor;
+	private int viewerBottomColor;
+
+	public static final Codec<ShardDisplaySettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+		Codec.BOOL.fieldOf("draw_mini_icons").forGetter(ShardDisplaySettings::drawMiniIcons),
+		ColorCodec.CODEC.fieldOf("library_color").forGetter(ShardDisplaySettings::libraryColor),
+		ColorCodec.CODEC.fieldOf("viewer_top_color").forGetter(ShardDisplaySettings::viewerTopColor),
+		ColorCodec.CODEC.fieldOf("viewer_bottom_color").forGetter(ShardDisplaySettings::viewerBottomColor)
+	).apply(instance, ShardDisplaySettings::new));
+
+	public static final PacketCodec<RegistryByteBuf, ShardDisplaySettings> PACKET_CODEC = PacketCodec.tuple(
+		PacketCodecs.BOOL, ShardDisplaySettings::drawMiniIcons,
+		PacketCodecs.INTEGER, ShardDisplaySettings::libraryColor,
+		PacketCodecs.INTEGER, ShardDisplaySettings::viewerTopColor,
+		PacketCodecs.INTEGER, ShardDisplaySettings::viewerBottomColor,
+		ShardDisplaySettings::new
+	);
+
+	public ShardDisplaySettings() {
+		this(true, 0xFF_3e2d58, 0xFF_441209, 0xFF_1c0906);
+	}
+
+	public ShardDisplaySettings(boolean drawMiniIcons, int libraryColor, int viewerTopColor, int viewerBottomColor) {
+		this.drawMiniIcons = drawMiniIcons;
+		this.libraryColor = libraryColor;
+		this.viewerTopColor = viewerTopColor;
+		this.viewerBottomColor = viewerBottomColor;
+	}
+
+	public static ShardDisplaySettings fromJson(JsonObject obj) {
+		return CODEC.parse(JsonOps.INSTANCE, obj).result().orElseThrow();
+	}
+
+	public void copyFrom(ShardDisplaySettings other) {
+		this.drawMiniIcons = other.drawMiniIcons;
+		this.libraryColor = other.libraryColor;
+		this.viewerTopColor = other.viewerTopColor;
+		this.viewerBottomColor = other.viewerBottomColor;
+	}
+
+	public boolean drawMiniIcons() {
+		return drawMiniIcons;
+	}
+
+	public int libraryColor() {
+		return libraryColor;
+	}
+
+	public int viewerTopColor() {
+		return viewerTopColor;
+	}
+
+	public int viewerBottomColor() {
+		return viewerBottomColor;
+	}
+}

--- a/src/main/java/net/modfest/scatteredshards/api/ShardDisplaySettings.java
+++ b/src/main/java/net/modfest/scatteredshards/api/ShardDisplaySettings.java
@@ -10,14 +10,17 @@ import net.minecraft.network.codec.PacketCodecs;
 import net.modfest.scatteredshards.api.impl.ColorCodec;
 
 public class ShardDisplaySettings {
+	// there's one more color in WMiniShard that seems nonstandard but it doesn't appear to matter?
 	private boolean drawMiniIcons;
 	private int libraryColor;
+	private int librarySetNameColor;
 	private int viewerTopColor;
 	private int viewerBottomColor;
 
 	public static final Codec<ShardDisplaySettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 		Codec.BOOL.fieldOf("draw_mini_icons").forGetter(ShardDisplaySettings::drawMiniIcons),
 		ColorCodec.CODEC.fieldOf("library_color").forGetter(ShardDisplaySettings::libraryColor),
+		ColorCodec.CODEC.fieldOf("library_set_name_color").forGetter(ShardDisplaySettings::librarySetNameColor),
 		ColorCodec.CODEC.fieldOf("viewer_top_color").forGetter(ShardDisplaySettings::viewerTopColor),
 		ColorCodec.CODEC.fieldOf("viewer_bottom_color").forGetter(ShardDisplaySettings::viewerBottomColor)
 	).apply(instance, ShardDisplaySettings::new));
@@ -25,18 +28,20 @@ public class ShardDisplaySettings {
 	public static final PacketCodec<RegistryByteBuf, ShardDisplaySettings> PACKET_CODEC = PacketCodec.tuple(
 		PacketCodecs.BOOL, ShardDisplaySettings::drawMiniIcons,
 		PacketCodecs.INTEGER, ShardDisplaySettings::libraryColor,
+		PacketCodecs.INTEGER, ShardDisplaySettings::librarySetNameColor,
 		PacketCodecs.INTEGER, ShardDisplaySettings::viewerTopColor,
 		PacketCodecs.INTEGER, ShardDisplaySettings::viewerBottomColor,
 		ShardDisplaySettings::new
 	);
 
 	public ShardDisplaySettings() {
-		this(true, 0xFF_3e2d58, 0xFF_441209, 0xFF_1c0906);
+		this(true, 0x778888, 0xccffcc, 0x777777, 0x555555);
 	}
 
-	public ShardDisplaySettings(boolean drawMiniIcons, int libraryColor, int viewerTopColor, int viewerBottomColor) {
+	public ShardDisplaySettings(boolean drawMiniIcons, int libraryColor, int librarySetNameColor, int viewerTopColor, int viewerBottomColor) {
 		this.drawMiniIcons = drawMiniIcons;
 		this.libraryColor = libraryColor;
+		this.librarySetNameColor = librarySetNameColor;
 		this.viewerTopColor = viewerTopColor;
 		this.viewerBottomColor = viewerBottomColor;
 	}
@@ -48,6 +53,7 @@ public class ShardDisplaySettings {
 	public void copyFrom(ShardDisplaySettings other) {
 		this.drawMiniIcons = other.drawMiniIcons;
 		this.libraryColor = other.libraryColor;
+		this.librarySetNameColor = other.librarySetNameColor;
 		this.viewerTopColor = other.viewerTopColor;
 		this.viewerBottomColor = other.viewerBottomColor;
 	}
@@ -58,6 +64,10 @@ public class ShardDisplaySettings {
 
 	public int libraryColor() {
 		return libraryColor;
+	}
+
+	public int librarySetNameColor() {
+		return librarySetNameColor;
 	}
 
 	public int viewerTopColor() {

--- a/src/main/java/net/modfest/scatteredshards/api/ShardLibrary.java
+++ b/src/main/java/net/modfest/scatteredshards/api/ShardLibrary.java
@@ -25,6 +25,8 @@ public interface ShardLibrary {
 
 	SetMultimap<Identifier, Identifier> shardSets();
 
+	ShardDisplaySettings shardDisplaySettings();
+
 	/**
 	 * Removes all Shards, ShardTypes, and ShardSets in this Library.
 	 */
@@ -53,6 +55,7 @@ public interface ShardLibrary {
 			}
 		).cast(),
 		ShardLibrary::shardSets,
+		ShardDisplaySettings.PACKET_CODEC, ShardLibrary::shardDisplaySettings,
 		ShardLibraryImpl::new
 	);
 }

--- a/src/main/java/net/modfest/scatteredshards/api/impl/ShardLibraryImpl.java
+++ b/src/main/java/net/modfest/scatteredshards/api/impl/ShardLibraryImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import net.minecraft.util.Identifier;
 import net.modfest.scatteredshards.api.MiniRegistry;
+import net.modfest.scatteredshards.api.ShardDisplaySettings;
 import net.modfest.scatteredshards.api.ShardLibrary;
 import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.api.shard.ShardType;
@@ -15,6 +16,7 @@ public class ShardLibraryImpl implements ShardLibrary {
 	private final MiniRegistry<Shard> shards;
 	private final MiniRegistry<ShardType> shardTypes;
 	private final SetMultimap<Identifier, Identifier> shardSets;
+	private final ShardDisplaySettings shardDisplaySettings;
 
 	@Override
 	public void clearAll() {
@@ -24,13 +26,19 @@ public class ShardLibraryImpl implements ShardLibrary {
 	}
 
 	public ShardLibraryImpl() {
-		this(new MiniRegistry<>(Shard.CODEC), new MiniRegistry<>(ShardType.CODEC), MultimapBuilder.hashKeys().hashSetValues(3).build());
+		this(
+			new MiniRegistry<>(Shard.CODEC),
+			new MiniRegistry<>(ShardType.CODEC),
+			MultimapBuilder.hashKeys().hashSetValues(3).build(),
+			new ShardDisplaySettings()
+		);
 	}
 
-	public ShardLibraryImpl(MiniRegistry<Shard> shards, MiniRegistry<ShardType> shardTypes, SetMultimap<Identifier, Identifier> shardSets) {
+	public ShardLibraryImpl(MiniRegistry<Shard> shards, MiniRegistry<ShardType> shardTypes, SetMultimap<Identifier, Identifier> shardSets, ShardDisplaySettings settings) {
 		this.shards = shards;
 		this.shardTypes = shardTypes;
 		this.shardSets = shardSets;
+		this.shardDisplaySettings = settings;
 	}
 
 	@Override
@@ -46,6 +54,11 @@ public class ShardLibraryImpl implements ShardLibrary {
 	@Override
 	public SetMultimap<Identifier, Identifier> shardSets() {
 		return shardSets;
+	}
+
+	@Override
+	public ShardDisplaySettings shardDisplaySettings() {
+		return shardDisplaySettings;
 	}
 
 	@Override

--- a/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
+++ b/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
@@ -1,0 +1,59 @@
+package net.modfest.scatteredshards.api.shard;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+
+public record ShardIconOffsets(Offset normal, Offset mini) {
+
+	public static final Codec<ShardIconOffsets> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+		Offset.CODEC.fieldOf("normal").forGetter(ShardIconOffsets::normal),
+		Offset.CODEC.fieldOf("mini").forGetter(ShardIconOffsets::mini)
+	).apply(instance, ShardIconOffsets::new));
+
+	public static final PacketCodec<RegistryByteBuf, ShardIconOffsets> PACKET_CODEC = PacketCodec.tuple(
+		Offset.PACKET_CODEC, ShardIconOffsets::normal,
+		Offset.PACKET_CODEC, ShardIconOffsets::mini,
+		ShardIconOffsets::new
+	);
+
+	public record Offset(int up, int left) {
+
+		public static final Codec<Offset> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+			Codec.INT.fieldOf("top").forGetter(Offset::up),
+			Codec.INT.fieldOf("left").forGetter(Offset::left)
+		).apply(instance, Offset::new));
+
+		public static final PacketCodec<RegistryByteBuf, Offset> PACKET_CODEC = PacketCodec.tuple(
+			PacketCodecs.INTEGER, Offset::up,
+			PacketCodecs.INTEGER, Offset::left,
+			Offset::new
+		);
+
+		public int down() {
+			// (32 (card) - 16 (item)) - up
+			return 16 - up;
+		}
+
+		public int right() {
+			// (24 (card) - 16 (item)) - left
+			return 8 - left;
+		}
+
+		public int miniDown() {
+			// (16 (card) - 6 (item)) - up
+			return 10 - up;
+		}
+
+		public int miniRight() {
+			// (12 (card) - 6 (item)) - left
+			return 6 - left;
+		}
+	}
+
+	public ShardIconOffsets(int normalLeft, int normalUp, int miniLeft, int miniUp) {
+		this(new Offset(normalUp, normalLeft), new Offset(miniUp, miniLeft));
+	}
+}

--- a/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
+++ b/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
@@ -6,18 +6,22 @@ import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
 
-public record ShardIconOffsets(Offset normal, Offset mini) {
+import java.util.Optional;
+
+public record ShardIconOffsets(Optional<Offset> normal, Optional<Offset> mini) {
 
 	public static final Codec<ShardIconOffsets> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-		Offset.CODEC.fieldOf("normal").forGetter(ShardIconOffsets::normal),
-		Offset.CODEC.fieldOf("mini").forGetter(ShardIconOffsets::mini)
+		Codec.optionalField("normal", Offset.CODEC, false).forGetter(ShardIconOffsets::normal),
+		Codec.optionalField("mini", Offset.CODEC, false).forGetter(ShardIconOffsets::mini)
 	).apply(instance, ShardIconOffsets::new));
 
 	public static final PacketCodec<RegistryByteBuf, ShardIconOffsets> PACKET_CODEC = PacketCodec.tuple(
-		Offset.PACKET_CODEC, ShardIconOffsets::normal,
-		Offset.PACKET_CODEC, ShardIconOffsets::mini,
+		PacketCodecs.optional(Offset.PACKET_CODEC), ShardIconOffsets::normal,
+		PacketCodecs.optional(Offset.PACKET_CODEC), ShardIconOffsets::mini,
 		ShardIconOffsets::new
 	);
+
+	public static final ShardIconOffsets DEFAULT = new ShardIconOffsets(Optional.empty(), Optional.empty());
 
 	public record Offset(int up, int left) {
 
@@ -31,6 +35,9 @@ public record ShardIconOffsets(Offset normal, Offset mini) {
 			PacketCodecs.INTEGER, Offset::left,
 			Offset::new
 		);
+
+		public static final Offset DEFAULT = new Offset(4, 4);
+		public static final Offset DEFAULT_MINI = new Offset(2, 2);
 
 		public int down() {
 			// (32 (card) - 16 (item)) - up
@@ -53,7 +60,11 @@ public record ShardIconOffsets(Offset normal, Offset mini) {
 		}
 	}
 
-	public ShardIconOffsets(int normalLeft, int normalUp, int miniLeft, int miniUp) {
-		this(new Offset(normalUp, normalLeft), new Offset(miniUp, miniLeft));
+	public Offset getNormal() {
+		return normal.orElse(Offset.DEFAULT);
+	}
+
+	public Offset getMini() {
+		return mini.orElse(Offset.DEFAULT_MINI);
 	}
 }

--- a/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
+++ b/src/main/java/net/modfest/scatteredshards/api/shard/ShardIconOffsets.java
@@ -40,22 +40,22 @@ public record ShardIconOffsets(Optional<Offset> normal, Optional<Offset> mini) {
 		public static final Offset DEFAULT_MINI = new Offset(2, 2);
 
 		public int down() {
-			// (32 (card) - 16 (item)) - up
+			// (32 (card) - 16 (icon)) - up
 			return 16 - up;
 		}
 
 		public int right() {
-			// (24 (card) - 16 (item)) - left
+			// (24 (card) - 16 (icon)) - left
 			return 8 - left;
 		}
 
 		public int miniDown() {
-			// (16 (card) - 6 (item)) - up
+			// (16 (card) - 6 (icon)) - up
 			return 10 - up;
 		}
 
 		public int miniRight() {
-			// (12 (card) - 6 (item)) - left
+			// (12 (card) - 6 (icon)) - left
 			return 6 - left;
 		}
 	}

--- a/src/main/java/net/modfest/scatteredshards/api/shard/ShardType.java
+++ b/src/main/java/net/modfest/scatteredshards/api/shard/ShardType.java
@@ -20,12 +20,12 @@ import net.modfest.scatteredshards.api.impl.ColorCodec;
 
 import java.util.Optional;
 
-public record ShardType(int textColor, int glowColor, IconOffset iconOffset, Optional<ParticleType<?>> collectParticle, Optional<SoundEvent> collectSound, int listOrder) {
+public record ShardType(int textColor, int glowColor, ShardIconOffsets iconMeta, Optional<ParticleType<?>> collectParticle, Optional<SoundEvent> collectSound, int listOrder) {
 
 	public static final Codec<ShardType> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 		ColorCodec.CODEC.fieldOf("text_color").forGetter(ShardType::textColor),
 		ColorCodec.CODEC.fieldOf("glow_color").forGetter(ShardType::glowColor),
-		IconOffset.CODEC.fieldOf("icon_offset").forGetter(ShardType::iconOffset),
+		ShardIconOffsets.CODEC.fieldOf("icon_offsets").forGetter(ShardType::iconMeta),
 		Codec.optionalField("collect_particle", Registries.PARTICLE_TYPE.getCodec(), false).forGetter(ShardType::collectParticle),
 		Codec.optionalField("collect_sound", SoundEvent.CODEC, false).forGetter(ShardType::collectSound),
 		Codec.INT.fieldOf("list_order").forGetter(ShardType::listOrder)
@@ -34,48 +34,18 @@ public record ShardType(int textColor, int glowColor, IconOffset iconOffset, Opt
 	public static final PacketCodec<RegistryByteBuf, ShardType> PACKET_CODEC = PacketCodec.tuple(
 		PacketCodecs.INTEGER, ShardType::textColor,
 		PacketCodecs.INTEGER, ShardType::glowColor,
-		IconOffset.PACKET_CODEC, ShardType::iconOffset,
+		ShardIconOffsets.PACKET_CODEC, ShardType::iconMeta,
 		PacketCodecs.optional(PacketCodecs.registryCodec(Registries.PARTICLE_TYPE.getCodec())), ShardType::collectParticle,
 		PacketCodecs.optional(SoundEvent.PACKET_CODEC), ShardType::collectSound,
 		PacketCodecs.INTEGER, ShardType::listOrder,
 		ShardType::new
 	);
 
-	//TODO: find a new home for this outside of ShardType
-	public record IconOffset(int up, int left)  {
-		public static final Codec<IconOffset> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-			Codec.INT.fieldOf("top").forGetter(IconOffset::up),
-			Codec.INT.fieldOf("left").forGetter(IconOffset::left)
-		).apply(instance, IconOffset::new));
-
-		public static final PacketCodec<RegistryByteBuf, IconOffset> PACKET_CODEC = PacketCodec.tuple(
-			PacketCodecs.INTEGER, IconOffset::up,
-			PacketCodecs.INTEGER, IconOffset::left,
-			IconOffset::new
-		);
-
-		public int up() {
-			return up;
-		}
-
-		public int down() {
-			return 16 - up;
-		}
-
-		public int left() {
-			return left;
-		}
-
-		public int right() {
-			return 8 - left;
-		}
-	}
-
 	public static final SoundEvent COLLECT_VISITOR_SOUND = SoundEvent.of(ScatteredShards.id("collect_visitor"));
 	public static final SoundEvent COLLECT_CHALLENGE_SOUND = SoundEvent.of(ScatteredShards.id("collect_challenge"));
 	public static final SoundEvent COLLECT_SECRET_SOUND = SoundEvent.of(ScatteredShards.id("collect_secret"));
 
-	public static final ShardType MISSING = new ShardType(0xFFFFFF, 0xFF00FF, new IconOffset(4, 4), Optional.empty(), Optional.empty(), -1);
+	public static final ShardType MISSING = new ShardType(0xFFFFFF, 0xFF00FF, new ShardIconOffsets(4, 4, 3, 3), Optional.empty(), Optional.empty(), -1);
 	public static final Identifier MISSING_ID = ScatteredShards.id("missing");
 
 	public static Identifier createModId(Identifier shardTypeId, String modId) {

--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
@@ -19,7 +19,7 @@ import net.modfest.scatteredshards.client.screen.ShardTabletGuiDescription;
 import net.modfest.scatteredshards.networking.ScatteredShardsNetworking;
 
 public class ScatteredShardsClient implements ClientModInitializer {
-	public static final boolean DRAW_MINI_ICONS = false;
+	public static final boolean DRAW_MINI_ICONS = true;
 	public static final int LEFT = 0xFF_3e2d58;
 	public static final int RIGHT_TOP = 0xFF_441209;
 	public static final int RIGHT_BOTTOM = 0xFF_1c0906;

--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
@@ -19,11 +19,6 @@ import net.modfest.scatteredshards.client.screen.ShardTabletGuiDescription;
 import net.modfest.scatteredshards.networking.ScatteredShardsNetworking;
 
 public class ScatteredShardsClient implements ClientModInitializer {
-	public static final boolean DRAW_MINI_ICONS = true;
-	public static final int LEFT = 0xFF_3e2d58;
-	public static final int RIGHT_TOP = 0xFF_441209;
-	public static final int RIGHT_BOTTOM = 0xFF_1c0906;
-
 	public static final String SHARD_MODIFY_TOAST_KEY = "toast.scattered_shards.shard_mod";
 
 	@Override

--- a/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
+++ b/src/main/java/net/modfest/scatteredshards/client/ScatteredShardsClient.java
@@ -19,7 +19,6 @@ import net.modfest.scatteredshards.client.screen.ShardTabletGuiDescription;
 import net.modfest.scatteredshards.networking.ScatteredShardsNetworking;
 
 public class ScatteredShardsClient implements ClientModInitializer {
-	public static final int ICON_Y_OFFSET = 6;
 	public static final boolean DRAW_MINI_ICONS = false;
 	public static final int LEFT = 0xFF_3e2d58;
 	public static final int RIGHT_TOP = 0xFF_441209;

--- a/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
@@ -3,12 +3,7 @@ package net.modfest.scatteredshards.client.render;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.LightmapTextureManager;
-import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.*;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
@@ -22,7 +17,6 @@ import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.block.ShardBlockEntity;
-import net.modfest.scatteredshards.client.ScatteredShardsClient;
 import org.joml.AxisAngle4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -168,8 +162,10 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 		float xpx = 1 / 24f * cardWidth;
 		float ypx = 1 / 32f * cardHeight;
 
+		ShardType.IconOffset offset = shardType.iconOffset();
+
 		shard.icon().ifLeft(stack -> {
-			matrices.translate(0, ScatteredShardsClient.ICON_Y_OFFSET * ypx, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card
+			matrices.translate((4 - offset.left()) * xpx, (8 - offset.up()) * ypx, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card
 			matrices.scale(-0.38f, 0.38f, 0.001f /*0.6f*/);
 
 
@@ -179,28 +175,28 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 		shard.icon().ifRight(texId -> {
 			VertexConsumer v = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(texId));
 
-			v.vertex(matrices.peek().getPositionMatrix(), dl.x + (4 * xpx), dl.y + (12 * ypx), dl.z - 0.002f)
+			v.vertex(matrices.peek().getPositionMatrix(), dl.x + (offset.right() * xpx), dl.y + (offset.down() * ypx), dl.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(1, 1)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), ul.x + (4 * xpx), ul.y - (4 * ypx), ul.z - 0.002f)
+			v.vertex(matrices.peek().getPositionMatrix(), ul.x + (offset.right() * xpx), ul.y - (offset.up() * ypx), ul.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(1, 0)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), ur.x - (4 * xpx), ur.y - (4 * ypx), ur.z - 0.002f)
+			v.vertex(matrices.peek().getPositionMatrix(), ur.x - (offset.left() * xpx), ur.y - (offset.up() * ypx), ur.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(0, 0)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), dr.x - (4 * xpx), dr.y + (12 * ypx), dr.z - 0.002f)
+			v.vertex(matrices.peek().getPositionMatrix(), dr.x - (offset.left() * xpx), dr.y + (offset.down() * ypx), dr.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(0, 1)
 				.overlay(overlay)

--- a/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RotationAxis;
 import net.modfest.scatteredshards.ScatteredShards;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
+import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
 import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.block.ShardBlockEntity;
@@ -162,7 +163,7 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 		float xpx = 1 / 24f * cardWidth;
 		float ypx = 1 / 32f * cardHeight;
 
-		ShardType.IconOffset offset = shardType.iconOffset();
+		ShardIconOffsets.Offset offset = shardType.iconMeta().normal();
 
 		shard.icon().ifLeft(stack -> {
 			matrices.translate((4 - offset.left()) * xpx, (8 - offset.up()) * ypx, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card

--- a/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
@@ -163,7 +163,7 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 		float xpx = 1 / 24f * cardWidth;
 		float ypx = 1 / 32f * cardHeight;
 
-		ShardIconOffsets.Offset offset = shardType.iconMeta().normal();
+		ShardIconOffsets.Offset offset = shardType.getOffsets().getNormal();
 
 		shard.icon().ifLeft(stack -> {
 			matrices.translate((4 - offset.left()) * xpx, (8 - offset.up()) * ypx, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card

--- a/src/main/java/net/modfest/scatteredshards/client/screen/ShardTabletGuiDescription.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/ShardTabletGuiDescription.java
@@ -102,7 +102,7 @@ public class ShardTabletGuiDescription extends LightweightGuiDescription {
 	@Override
 	public void addPainters() {
 		selectorPanel.setBackgroundPainter(BackgroundPainter.createColorful(
-			ScatteredShardsAPI.getClientLibrary().shardDisplaySettings().libraryColor()
+			0xFF_000000 | (ScatteredShardsAPI.getClientLibrary().shardDisplaySettings().libraryColor())
 		));
 	}
 

--- a/src/main/java/net/modfest/scatteredshards/client/screen/ShardTabletGuiDescription.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/ShardTabletGuiDescription.java
@@ -6,13 +6,12 @@ import io.github.cottonmc.cotton.gui.client.LightweightGuiDescription;
 import io.github.cottonmc.cotton.gui.widget.WListPanel;
 import io.github.cottonmc.cotton.gui.widget.WPanelWithInsets;
 import io.github.cottonmc.cotton.gui.widget.WPlainPanel;
-import io.github.cottonmc.cotton.gui.widget.WScrollBar;
-import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.Insets;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
 import net.minecraft.util.Identifier;
+import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.ShardCollection;
 import net.modfest.scatteredshards.api.ShardLibrary;
 import net.modfest.scatteredshards.api.shard.Shard;
@@ -102,7 +101,9 @@ public class ShardTabletGuiDescription extends LightweightGuiDescription {
 
 	@Override
 	public void addPainters() {
-		selectorPanel.setBackgroundPainter(BackgroundPainter.createColorful(ScatteredShardsClient.LEFT));
+		selectorPanel.setBackgroundPainter(BackgroundPainter.createColorful(
+			ScatteredShardsAPI.getClientLibrary().shardDisplaySettings().libraryColor()
+		));
 	}
 
 	public static class Screen extends CottonClientScreen {

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -55,12 +55,10 @@ public class WMiniShard extends WWidget {
 		int color = (isCollected) ? 0xFF_FFFFFF : 0xFF_668866;
 		float opacity = (isCollected) ? 1.0f : 0.6f;
 		ScreenDrawing.texturedRect(context, x, y, 12, 16, tex, color, opacity);
-		if (isCollected && ScatteredShardsClient.DRAW_MINI_ICONS) {
-			//TODO: configure offset
+		if (isCollected && ScatteredShardsAPI.getClientLibrary().shardDisplaySettings().drawMiniIcons()) {
 			//Maybe draw a teeny tiny icon
 
 			ShardIconOffsets.Offset offset = this.shardType.getOffsets().getMini();
-
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();
 				context.getMatrices().translate(x + offset.left(), y + offset.up(), 0);

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -14,6 +14,7 @@ import net.minecraft.util.Identifier;
 import net.modfest.scatteredshards.ScatteredShards;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.shard.Shard;
+import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.client.ScatteredShardsClient;
 
@@ -57,15 +58,18 @@ public class WMiniShard extends WWidget {
 		if (isCollected && ScatteredShardsClient.DRAW_MINI_ICONS) {
 			//TODO: configure offset
 			//Maybe draw a teeny tiny icon
+
+			ShardIconOffsets.Offset offset = this.shardType.iconMeta().mini();
+
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();
-				context.getMatrices().translate(x + 3, y + 3, 0);
+				context.getMatrices().translate(x + offset.left(), y + offset.up(), 0);
 				context.getMatrices().scale(0.375f, 0.375f, 1); // 16px -> 6px
 				RenderSystem.enableDepthTest();
 				context.drawItemWithoutEntity(it, 0, 0);
 				context.getMatrices().pop();
 			});
-			shard.icon().ifRight((it) -> ScreenDrawing.texturedRect(context, x + 3, y + 3, 6, 6, it, 0xFF_FFFFFF));
+			shard.icon().ifRight((it) -> ScreenDrawing.texturedRect(context, x + offset.left(), y + offset.up(), 6, 6, it, 0xFF_FFFFFF));
 		}
 
 		boolean hovered = (mouseX >= 0 && mouseY >= 0 && mouseX < getWidth() && mouseY < getHeight());

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -64,12 +64,12 @@ public class WMiniShard extends WWidget {
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();
 				context.getMatrices().translate(x + offset.left(), y + offset.up(), 0);
-				context.getMatrices().scale(0.375f, 0.375f, 1); // 16px -> 6px
+				context.getMatrices().scale(0.5f, 0.5f, 1); // 16px -> 8px
 				RenderSystem.enableDepthTest();
 				context.drawItemWithoutEntity(it, 0, 0);
 				context.getMatrices().pop();
 			});
-			shard.icon().ifRight((it) -> ScreenDrawing.texturedRect(context, x + offset.left(), y + offset.up(), 6, 6, it, 0xFF_FFFFFF));
+			shard.icon().ifRight((it) -> ScreenDrawing.texturedRect(context, x + offset.left(), y + offset.up(), 8, 8, it, 0xFF_FFFFFF));
 		}
 
 		boolean hovered = (mouseX >= 0 && mouseY >= 0 && mouseX < getWidth() && mouseY < getHeight());

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -59,7 +59,7 @@ public class WMiniShard extends WWidget {
 			//TODO: configure offset
 			//Maybe draw a teeny tiny icon
 
-			ShardIconOffsets.Offset offset = this.shardType.iconMeta().mini();
+			ShardIconOffsets.Offset offset = this.shardType.getOffsets().getMini();
 
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WMiniShard.java
@@ -55,6 +55,7 @@ public class WMiniShard extends WWidget {
 		float opacity = (isCollected) ? 1.0f : 0.6f;
 		ScreenDrawing.texturedRect(context, x, y, 12, 16, tex, color, opacity);
 		if (isCollected && ScatteredShardsClient.DRAW_MINI_ICONS) {
+			//TODO: configure offset
 			//Maybe draw a teeny tiny icon
 			shard.icon().ifLeft((it) -> {
 				context.getMatrices().push();

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -207,7 +207,7 @@ public class WShardPanel extends WPlainPanel {
 			context.fillGradient(
 				left + 5, top + 5,
 				left + 5 + panel.getWidth() - 10, top + 5 + panel.getHeight() - 10,
-				displaySettings.viewerTopColor(), displaySettings.viewerBottomColor()
+				0xFF_000000 | displaySettings.viewerTopColor(), 0xFF_000000 | displaySettings.viewerBottomColor()
 			);
 		});
 	}

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -19,6 +19,7 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.modfest.scatteredshards.ScatteredShards;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
+import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
 import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.client.ScatteredShardsClient;
@@ -67,7 +68,7 @@ public class WShardPanel extends WPlainPanel {
 
 		int cardScale = 2;
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
-		ShardType.IconOffset offset = this.shardType.iconOffset();
+		ShardIconOffsets.Offset offset = this.shardType.iconMeta().normal();
 		this.icon.setLocation(this.insets.left() + cardX + (offset.left() * cardScale), this.insets.top() + 40 + (offset.up() * cardScale));
 
 		backing.setImage(ShardType.getFrontTexture(shardTypeId));
@@ -152,7 +153,7 @@ public class WShardPanel extends WPlainPanel {
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
 		add(backing, cardX, 40, 24 * cardScale, 32 * cardScale);
 
-		ShardType.IconOffset offset = this.shardType.iconOffset();
+		ShardIconOffsets.Offset offset = this.shardType.iconMeta().normal();
 		add(icon, cardX + (offset.left() * cardScale), 40 + (offset.up() * cardScale), 16 * cardScale, 16 * cardScale);
 
 

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -68,7 +68,7 @@ public class WShardPanel extends WPlainPanel {
 
 		int cardScale = 2;
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
-		ShardIconOffsets.Offset offset = this.shardType.iconMeta().normal();
+		ShardIconOffsets.Offset offset = this.shardType.getOffsets().getNormal();
 		this.icon.setLocation(this.insets.left() + cardX + (offset.left() * cardScale), this.insets.top() + 40 + (offset.up() * cardScale));
 
 		backing.setImage(ShardType.getFrontTexture(shardTypeId));
@@ -153,7 +153,7 @@ public class WShardPanel extends WPlainPanel {
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
 		add(backing, cardX, 40, 24 * cardScale, 32 * cardScale);
 
-		ShardIconOffsets.Offset offset = this.shardType.iconMeta().normal();
+		ShardIconOffsets.Offset offset = this.shardType.getOffsets().getNormal();
 		add(icon, cardX + (offset.left() * cardScale), 40 + (offset.up() * cardScale), 16 * cardScale, 16 * cardScale);
 
 

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -19,10 +19,10 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.modfest.scatteredshards.ScatteredShards;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
-import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
+import net.modfest.scatteredshards.api.ShardDisplaySettings;
 import net.modfest.scatteredshards.api.shard.Shard;
+import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
 import net.modfest.scatteredshards.api.shard.ShardType;
-import net.modfest.scatteredshards.client.ScatteredShardsClient;
 import net.modfest.scatteredshards.client.screen.widget.scalable.WScaledLabel;
 import net.modfest.scatteredshards.client.screen.widget.scalable.WScaledText;
 import net.modfest.scatteredshards.client.screen.widget.scalable.WShardIcon;
@@ -199,11 +199,16 @@ public class WShardPanel extends WPlainPanel {
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void addPainters() {
+		ShardDisplaySettings displaySettings = ScatteredShardsAPI.getClientLibrary().shardDisplaySettings();
 		this.setBackgroundPainter((context, left, top, panel) -> {
 			context.setShaderColor(1, 1, 1, 1);
 			ScreenDrawing.drawGuiPanel(context, left, top, panel.getWidth(), panel.getHeight());
 			ScreenDrawing.drawBeveledPanel(context, left + 4, top + 4, panel.getWidth() - 8, panel.getHeight() - 8);
-			context.fillGradient(left + 5, top + 5, left + 5 + panel.getWidth() - 10, top + 5 + panel.getHeight() - 10, ScatteredShardsClient.RIGHT_TOP, ScatteredShardsClient.RIGHT_BOTTOM);
+			context.fillGradient(
+				left + 5, top + 5,
+				left + 5 + panel.getWidth() - 10, top + 5 + panel.getHeight() - 10,
+				displaySettings.viewerTopColor(), displaySettings.viewerBottomColor()
+			);
 		});
 	}
 

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -64,6 +64,12 @@ public class WShardPanel extends WPlainPanel {
 	 */
 	public WShardPanel setType(Identifier shardTypeId, ShardType value) {
 		this.shardType = value;
+
+		int cardScale = 2;
+		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
+		ShardType.IconOffset offset = this.shardType.iconOffset();
+		this.icon.setLocation(this.insets.left() + cardX + (offset.left() * cardScale), this.insets.top() + 40 + (offset.up() * cardScale));
+
 		backing.setImage(ShardType.getFrontTexture(shardTypeId));
 		typeDescription.setText(ShardType.getDescription(shardTypeId));
 		typeDescription.setColor(value::textColor);
@@ -146,7 +152,8 @@ public class WShardPanel extends WPlainPanel {
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
 		add(backing, cardX, 40, 24 * cardScale, 32 * cardScale);
 
-		add(icon, cardX + (4 * cardScale), 40 + (ScatteredShardsClient.ICON_Y_OFFSET * cardScale), 16 * cardScale, 16 * cardScale);
+		ShardType.IconOffset offset = this.shardType.iconOffset();
+		add(icon, cardX + (offset.left() * cardScale), 40 + (offset.up() * cardScale), 16 * cardScale, 16 * cardScale);
 
 
 		add(lore, 0, 113, getLayoutWidth(), 32);

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardSetPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardSetPanel.java
@@ -5,6 +5,7 @@ import io.github.cottonmc.cotton.gui.widget.WWidget;
 import io.github.cottonmc.cotton.gui.widget.data.Insets;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
+import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.ShardCollection;
 import net.modfest.scatteredshards.api.ShardLibrary;
 import net.modfest.scatteredshards.api.shard.Shard;
@@ -24,7 +25,7 @@ public class WShardSetPanel extends WPanelWithInsets {
 	};
 
 	private final WScaledLabel sourceLabel = new WScaledLabel(Text.literal(""), 0.8f)
-		.setColor(0xFF_CCFFCC)
+		.setColor(0xFF_000000 | ScatteredShardsAPI.getClientLibrary().shardDisplaySettings().librarySetNameColor())
 		.setShadow(true);
 	private final List<WMiniShard> shards = new ArrayList<>();
 

--- a/src/main/java/net/modfest/scatteredshards/command/AwardCommand.java
+++ b/src/main/java/net/modfest/scatteredshards/command/AwardCommand.java
@@ -39,13 +39,14 @@ public class AwardCommand {
 	}
 
 	public static void register(CommandNode<ServerCommandSource> parent) {
-		var awardCommand = Node.literal("award").build();
-		var awardPlayerArgument = Node.players("players").build();
-		var awardIdArgument = Node.shardId("shard_id")
-			.executes(AwardCommand::award)
+		var awardCommand = Node.literal("award")
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.award"), 2)
 			)
+			.build();
+		var awardPlayerArgument = Node.players("players").build();
+		var awardIdArgument = Node.shardId("shard_id")
+			.executes(AwardCommand::award)
 			.build();
 		awardCommand.addChild(awardPlayerArgument);
 		awardPlayerArgument.addChild(awardIdArgument);

--- a/src/main/java/net/modfest/scatteredshards/command/BlockCommand.java
+++ b/src/main/java/net/modfest/scatteredshards/command/BlockCommand.java
@@ -48,12 +48,13 @@ public class BlockCommand {
 
 	public static void register(CommandNode<ServerCommandSource> parent) {
 		//Usage: /shard block <shard_id>
-		var blockCommand = Node.literal("block").build();
-		var blockIdArgument = Node.shardId("shard_id")
-			.executes(BlockCommand::block)
+		var blockCommand = Node.literal("block")
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.block"), 2)
 			)
+			.build();
+		var blockIdArgument = Node.shardId("shard_id")
+			.executes(BlockCommand::block)
 			.build();
 		var blockInteractArgument = Node.booleanValue("can_interact").build();
 		var blockGlowSizeArgument = Node.floatValue("glow_size").build();

--- a/src/main/java/net/modfest/scatteredshards/command/CollectCommand.java
+++ b/src/main/java/net/modfest/scatteredshards/command/CollectCommand.java
@@ -29,12 +29,13 @@ public class CollectCommand {
 	}
 
 	public static void register(CommandNode<ServerCommandSource> parent) {
-		var collectCommand = Node.literal("collect").build();
-		var collectIdArgument = Node.shardId("shard_id")
-			.executes(CollectCommand::collect)
+		var collectCommand = Node.literal("collect")
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.collect"), 2)
 			)
+			.build();
+		var collectIdArgument = Node.shardId("shard_id")
+			.executes(CollectCommand::collect)
 			.build();
 		collectCommand.addChild(collectIdArgument);
 		parent.addChild(collectCommand);

--- a/src/main/java/net/modfest/scatteredshards/command/LibraryCommand.java
+++ b/src/main/java/net/modfest/scatteredshards/command/LibraryCommand.java
@@ -111,17 +111,18 @@ public class LibraryCommand {
 
 		//Usage: /shard library delete all
 		var deleteAllCommand = Node.literal("all")
-			.executes(LibraryCommand::deleteAll)
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.library.delete.all"), 4)
 			)
+			.executes(LibraryCommand::deleteAll)
 			.build();
 		deleteCommand.addChild(deleteAllCommand);
 
 		var migrateCommand = Node.literal("migrate")
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.library.migrate"), 3)
-			).build();
+			)
+			.build();
 		var migrateShardArg = Node.shardId("shard_id").build();
 		var migrateModArg = Node.stringArgument("mod_id").suggests(Node::suggestModIds).build();
 		var migrateShardTypeArg = Node.identifier("shard_type").suggests(Node::suggestShardTypes)

--- a/src/main/java/net/modfest/scatteredshards/command/UncollectCommand.java
+++ b/src/main/java/net/modfest/scatteredshards/command/UncollectCommand.java
@@ -75,10 +75,10 @@ public class UncollectCommand {
 
 		//syntax: uncollect all
 		var uncollectAllCommand = Node.literal("all")
-			.executes(UncollectCommand::uncollectAll)
 			.requires(
 				Permissions.require(ScatteredShards.permission("command.uncollect.all"), 2)
 			)
+			.executes(UncollectCommand::uncollectAll)
 			.build();
 		uncollectCommand.addChild(uncollectAllCommand);
 	}

--- a/src/main/java/net/modfest/scatteredshards/load/ShardTypeLoader.java
+++ b/src/main/java/net/modfest/scatteredshards/load/ShardTypeLoader.java
@@ -15,6 +15,7 @@ import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
 import net.modfest.scatteredshards.ScatteredShards;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
+import net.modfest.scatteredshards.api.ShardDisplaySettings;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.networking.S2CSyncLibrary;
 import org.jetbrains.annotations.NotNull;
@@ -46,6 +47,14 @@ public class ShardTypeLoader extends JsonDataLoader implements IdentifiableResou
 		for (var entry : cache.entrySet()) {
 			try {
 				JsonObject root = JsonHelper.asObject(entry.getValue(), "root element");
+
+				//TODO: improve this accursed way of datafying these settings
+				if (root.has("display_settings")) {
+					library.shardDisplaySettings().copyFrom(ShardDisplaySettings.fromJson(root.getAsJsonObject("display_settings")));
+
+					// remove it all to avoid messing with shard processing
+					root.remove("display_settings");
+				}
 
 				if (root.has("text_color")) {
 					library.shardTypes().put(entry.getKey(), ShardType.fromJson(root));


### PR DESCRIPTION
* Adds optional icon offsets per shard type to adjust where on the card the icon is rendered, measured as distance from the top left in card pixels (sample below)
  * If absent, offsets default to original values (equivalent to {top: 4, left: 4}, giving the {4, 4, 4, 12} insets described in `ShardBlockEntityRenderer`)
* Changes mini icon size to 8x8 to be a nice 1/2 scale, matching the card and keeping pixels square
* Adds data control of shard menu colors & whether mini icons are drawn via an extra object alongside the cards (sample below)
  * If absent, settings default to original values
* Moves command permission requirements towards their root, to avoid getting just to the end of a command before realizing you don't have access and shouldn't even be seeing it

Sample shards json with new data:
```
{
	"display_settings": {
		"draw_mini_icons": true,
		"library_color": "#331714",
		"library_set_name_color": "#f4eae0",
		"viewer_top_color": "#290800",
		"viewer_bottom_color": "#180101"
	},
	"mf_121:cartography": {
		"text_color": "#43f099",
		"glow_color": "#00ff48",
		"icon_offsets": {
			"normal": {
				"top": 15,
				"left": 4
			},
			"mini": {
				"top": 7,
				"left": 2
			}
		},
		"collect_particle": "minecraft:glow",
		"collect_sound": {
			"sound_id": "scattered_shards:collect_visitor"
		},
		"list_order": 1
	}
}
```