### PR TITLE
Usage of Item Components instead of raw NBT data in ShardCreatorGuiDescription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	include libs.fpapi
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/${modId}.accesswidener")
+}
+
 processResources {
 	final Map<String, String> meta = [
 		version       : version,

--- a/src/main/java/net/modfest/scatteredshards/client/screen/ShardCreatorGuiDescription.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/ShardCreatorGuiDescription.java
@@ -2,6 +2,7 @@ package net.modfest.scatteredshards.client.screen;
 
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
@@ -161,7 +162,7 @@ public class ShardCreatorGuiDescription extends LightweightGuiDescription {
 			ComponentType<T> componentType = (ComponentType<T>) ItemStringReader.Reader.readComponentType(reader);
 			reader.skipWhitespace();
 			if (!known.add(componentType))
-				throw ItemStringReader.REPEATED_COMPONENT_EXCEPTION.create(componentType);
+				throw new SimpleCommandExceptionType(Text.literal("Same component cannot appear twice")).create();
 
 			if (negation)
 				changesBuilder.remove(componentType);
@@ -178,7 +179,7 @@ public class ShardCreatorGuiDescription extends LightweightGuiDescription {
 
 				changesBuilder.add(componentType, dataResult.getOrThrow(error -> {
 					reader.setCursor(index);
-					return ItemStringReader.MALFORMED_COMPONENT_EXCEPTION.createWithContext(reader, componentType.toString(), error);
+					return new SimpleCommandExceptionType(Text.literal("Component is malformed")).create();
 				}));
 
 				reader.skipWhitespace();
@@ -192,7 +193,7 @@ public class ShardCreatorGuiDescription extends LightweightGuiDescription {
 			reader.skip();
 			reader.skipWhitespace();
 			if (!reader.canRead())
-				throw ItemStringReader.COMPONENT_EXPECTED_EXCEPTION.createWithContext(reader);
+				throw new SimpleCommandExceptionType(Text.literal("Expected component")).create();
 		}
 
 		// End of components list

--- a/src/main/resources/assets/scattered_shards/lang/en_us.json
+++ b/src/main/resources/assets/scattered_shards/lang/en_us.json
@@ -40,7 +40,7 @@
 	"gui.scattered_shards.creator.icon.texture": "Texture Icon",
 	"gui.scattered_shards.creator.icon.item": "Item Icon",
 	"gui.scattered_shards.creator.field.item.id": "Item ID...",
-	"gui.scattered_shards.creator.field.item.nbt": "Item NBT...",
+	"gui.scattered_shards.creator.field.item.component": "Item Component...",
 	"gui.scattered_shards.creator.field.texture": "Texture path...",
 	"gui.scattered_shards.creator.toggle.mod_icon": "Use mod icon",
 	"gui.scattered_shards.creator.button.save": "Save",

--- a/src/main/resources/assets/scattered_shards/lang/en_us.json
+++ b/src/main/resources/assets/scattered_shards/lang/en_us.json
@@ -40,7 +40,7 @@
 	"gui.scattered_shards.creator.icon.texture": "Texture Icon",
 	"gui.scattered_shards.creator.icon.item": "Item Icon",
 	"gui.scattered_shards.creator.field.item.id": "Item ID...",
-	"gui.scattered_shards.creator.field.item.component": "Item Component...",
+	"gui.scattered_shards.creator.field.item.component": "Item Components...",
 	"gui.scattered_shards.creator.field.texture": "Texture path...",
 	"gui.scattered_shards.creator.toggle.mod_icon": "Use mod icon",
 	"gui.scattered_shards.creator.button.save": "Save",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,6 +27,7 @@
 		"libgui": ">=${libgui}",
 		"fabric-permissions-api-v0": ">=${fpapi}"
 	},
+	"accessWidener": "${modId}.accesswidener",
 	"entrypoints": {
 		"main": [
 			"net.modfest.scatteredshards.ScatteredShards"

--- a/src/main/resources/scattered_shards.accesswidener
+++ b/src/main/resources/scattered_shards.accesswidener
@@ -1,6 +1,3 @@
 accessWidener v2 named
 
 accessible class net/minecraft/command/argument/ItemStringReader$Reader
-accessible field net/minecraft/command/argument/ItemStringReader REPEATED_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-accessible field net/minecraft/command/argument/ItemStringReader COMPONENT_EXPECTED_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-accessible field net/minecraft/command/argument/ItemStringReader MALFORMED_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;

--- a/src/main/resources/scattered_shards.accesswidener
+++ b/src/main/resources/scattered_shards.accesswidener
@@ -1,0 +1,6 @@
+accessWidener v2 named
+
+accessible class net/minecraft/command/argument/ItemStringReader$Reader
+accessible field net/minecraft/command/argument/ItemStringReader REPEATED_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
+accessible field net/minecraft/command/argument/ItemStringReader COMPONENT_EXPECTED_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
+accessible field net/minecraft/command/argument/ItemStringReader MALFORMED_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;


### PR DESCRIPTION
### Context

Since 1.20.5, items are using item components instead of NBT data.

This change made it uncomfortable for players to add data to their items in the Shard Creator screen _(e.g. for custom item models, damage, glittering effects, etc)_.

### Change

This PR adjusts the code of the Shard Creator screen to be using _(and referring)_ them as item components.
The logic behind the parser is adopted from the `/give` command and therefore should be fully compatible with what players already got and with what they feel comfortable with.