### PR TITLE
Render and buildscript fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 loom {
-	accessWidenerPath = file("src/main/resources/${modId}.accesswidener")
+	accessWidenerPath = file("src/main/resources/scattered_shards.accesswidener")
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ loom {
 processResources {
 	final Map<String, String> meta = [
 		version       : version,
-		modId         : modId,
 		modName       : modName,
 		modDescription: modDescription,
 		homepage      : "https://modrinth.com/mod/${slug}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ fabric.loom.multiProjectOptimisation=true
 group=net.modfest
 user=ModFest
 slug=scattered-shards
-modId=scattered_shards
 modName=Scattered Shards
 modDescription=Collectible trading cards... without the trading. Shards!
 authors=Falkreon, acikek

--- a/src/main/java/net/modfest/scatteredshards/api/shard/ShardTextureSettings.java
+++ b/src/main/java/net/modfest/scatteredshards/api/shard/ShardTextureSettings.java
@@ -34,7 +34,7 @@ public record ShardTextureSettings (Optional<Size> size, Optional<Size> miniSize
 			ShardTextureSettings.Size::new
 		);
 
-		public static final Size DEFAULT = new Size(18, 24);
+		public static final Size DEFAULT = new Size(24, 32);
 		public static final Size DEFAULT_MINI = new Size(12, 16);
 	}
 

--- a/src/main/java/net/modfest/scatteredshards/block/ShardBlock.java
+++ b/src/main/java/net/modfest/scatteredshards/block/ShardBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
 import net.modfest.scatteredshards.ScatteredShardsContent;
 import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.ShardLibrary;
@@ -114,13 +115,31 @@ public class ShardBlock extends Block implements BlockEntityProvider {
 			tryCollect(world, player, be);
 		}
 	}
-
+	
+	@Override
+	public ItemStack getPickStack(WorldView world, BlockPos pos, BlockState state) {
+		
+		BlockEntity entity = world.getBlockEntity(pos);
+		if (world.isClient() && entity instanceof ShardBlockEntity shardEntity) {
+			Identifier shardId = shardEntity.getShardId();
+			ShardLibrary library = ScatteredShardsAPI.getClientLibrary();
+			return createShardBlock(library, shardId, shardEntity.canInteract(), shardEntity.getGlowSize(), shardEntity.getGlowStrength());
+		} else {
+			
+			return super.getPickStack(world, pos, state);
+		}
+	}
+	
 	/**
 	 * Creates a shard block
 	 *
 	 * @return the shard block
 	 */
 	public static ItemStack createShardBlock(ShardLibrary library, Identifier shardId, boolean canInteract, float glowSize, float glowStrength) {
+		Shard shard = library.shards().get(shardId).orElse(Shard.MISSING_SHARD);
+		ShardType shardType = library.shardTypes().get(shard.shardTypeId()).orElse(ShardType.MISSING);
+		return createShardBlock(shardType, shardId, shard, canInteract, glowSize, glowStrength);
+		/*
 		ItemStack stack = new ItemStack(ScatteredShardsContent.SHARD_BLOCK);
 
 		NbtCompound blockEntityTag = new NbtCompound();
@@ -131,6 +150,31 @@ public class ShardBlock extends Block implements BlockEntityProvider {
 		Shard shard = library.shards().get(shardId).orElse(Shard.MISSING_SHARD);
 		stack.set(DataComponentTypes.ITEM_NAME, shard.name());
 		ShardType shardType = library.shardTypes().get(shard.shardTypeId()).orElse(ShardType.MISSING);
+		Text shardTypeDesc = ShardType.getDescription(shard.shardTypeId()).copy().fillStyle(Style.EMPTY.withColor(shardType.textColor()));
+		LoreComponent lore = new LoreComponent(List.of(shardTypeDesc));
+		stack.set(DataComponentTypes.LORE, lore);
+
+		blockEntityTag.putBoolean("CanInteract", canInteract);
+
+		NbtCompound glowTag = new NbtCompound();
+		glowTag.putFloat("size", glowSize);
+		glowTag.putFloat("strength", glowStrength);
+		blockEntityTag.put("Glow", glowTag);
+
+		stack.set(DataComponentTypes.BLOCK_ENTITY_DATA, NbtComponent.of(blockEntityTag));
+
+		return stack;*/
+	}
+	
+	public static ItemStack createShardBlock(ShardType shardType, Identifier shardId, Shard shard, boolean canInteract, float glowSize, float glowStrength) {
+		ItemStack stack = new ItemStack(ScatteredShardsContent.SHARD_BLOCK);
+		
+		NbtCompound blockEntityTag = new NbtCompound();
+		blockEntityTag.putString("id", ScatteredShardsContent.SHARD_BLOCK_ID.toString()); // required, see NbtComponent.CODEC_WITH_ID
+		blockEntityTag.putString("Shard", shardId.toString());
+
+		//Fill in name / lore
+		stack.set(DataComponentTypes.ITEM_NAME, shard.name());
 		Text shardTypeDesc = ShardType.getDescription(shard.shardTypeId()).copy().fillStyle(Style.EMPTY.withColor(shardType.textColor()));
 		LoreComponent lore = new LoreComponent(List.of(shardTypeDesc));
 		stack.set(DataComponentTypes.LORE, lore);

--- a/src/main/java/net/modfest/scatteredshards/block/ShardBlockEntity.java
+++ b/src/main/java/net/modfest/scatteredshards/block/ShardBlockEntity.java
@@ -80,6 +80,10 @@ public class ShardBlockEntity extends BlockEntity {
 	public float getGlowStrength() {
 		return glowStrength;
 	}
+	
+	public boolean canInteract() {
+		return canInteract;
+	}
 
 	@Override
 	protected void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {

--- a/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
+++ b/src/main/java/net/modfest/scatteredshards/client/render/ShardBlockEntityRenderer.java
@@ -27,11 +27,14 @@ import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.block.ShardBlockEntity;
 import net.modfest.scatteredshards.util.ModMetaUtil;
 import org.joml.AxisAngle4f;
+import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
 @Environment(EnvType.CLIENT)
 public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockEntity> {
+	public static final float BLOCK_SCALE = 0.75f;
+	
 	private static final Identifier DISTANCE_GLOW_TEX = ScatteredShards.id("textures/entity/shard_distance_glow.png");
 	private static final Identifier DISTANCE_HALO_TEX = ScatteredShards.id("textures/entity/shard_distance_halo.png");
 
@@ -70,13 +73,16 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 
 		/*
 		 * A note about scale here:
-		 * 0.75m or 24/32 == 32px on the card face.
-		 * The card is 24 x 32, meaning it's 0.75 x as wide as it is tall.
-		 * 0.75 x 0.75 == 0.5625 or 18/32 is the card's proper width
+		 * Cards are about 0.75m in their largest dimension.
+		 * 
+		 * Pixel density is largestSize px / BLOCK_SCALE m
+		 * That defaults to 32/0.75 or 42.6 px/m, but can vary depending on the shard backing size.
 		 */
 		ShardTextureSettings.Size size = shardType.getTextureSettings().getSize();
-		float cardHeight = size.height() / 32f;
-		float cardWidth = size.width() / 32f;
+		float largestSize = Math.max(size.width(), size.height());
+		float metersPerPixel = BLOCK_SCALE / largestSize;
+		float cardHeight = size.height() * metersPerPixel;
+		float cardWidth = size.width() * metersPerPixel;
 
 		float halfHeight = cardHeight / 2f;
 		float halfWidth = cardWidth / 2f;
@@ -156,58 +162,47 @@ public class ShardBlockEntityRenderer implements BlockEntityRenderer<ShardBlockE
 			.light(actualLight)
 			.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-		/*
-		 * Another note about scale:
-		 * because there are a different number of texels in each dimension, we need a separate pixel ratio for width
-		 * and height:
-		 *
-		 * For width, 1.0 equates to 24px, so the ratio is 1/24f
-		 * For height, 1.0 equates to 32px, so the ratio is 1/32f
-		 *
-		 * To translate this into distance units, we multiply by the size of the card in meters in that dimensions.
-		 *
-		 * Once that's done, with our {4, 4, 4, 12} insets, we arrive at a perfect 16px x 16px square
-		 * (in card-image pixels) for the card-icon texture
-		 *
-		 */
-		float xpx = 1 / 32f * cardWidth;
-		float ypx = 1 / 32f * cardHeight;
-
 		ShardIconOffsets.Offset offset = shardType.getOffsets().getNormal();
 
 		shard.icon().ifLeft(stack -> {
-			matrices.translate((4 - offset.left()) * xpx, (8 - offset.up()) * ypx, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card
+			matrices.translate((offset.left() - 8) * metersPerPixel, (offset.up() - 8) * metersPerPixel, -0.005f); //extra -0.002 here to prevent full-cubes from zfighting the card
 			matrices.scale(-0.38f, 0.38f, 0.001f /*0.6f*/);
-
 
 			MinecraftClient.getInstance().getItemRenderer().renderItem(stack, ModelTransformationMode.GUI, actualLight, OverlayTexture.DEFAULT_UV, matrices, vertexConsumers, entity.getWorld(), 0);
 		});
 
 		shard.icon().ifRight(texId -> {
 			VertexConsumer v = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(texId));
+			
+			Matrix4f positionMatrix = matrices.peek().getPositionMatrix();
+			
+			int left = offset.left();
+			int top = offset.up();
+			int right = left + 16;
+			int bottom = top + 16;
 
-			v.vertex(matrices.peek().getPositionMatrix(), dl.x + (offset.right() * xpx), dl.y + (offset.down() * ypx), dl.z - 0.002f)
+			v.vertex(positionMatrix, ur.x - (right * metersPerPixel), ur.y - (bottom * metersPerPixel), ur.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(1, 1)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), ul.x + (offset.right() * xpx), ul.y - (offset.up() * ypx), ul.z - 0.002f)
+			v.vertex(positionMatrix, ur.x - (right * metersPerPixel), ur.y - (top * metersPerPixel), ur.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(1, 0)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), ur.x - (offset.left() * xpx), ur.y - (offset.up() * ypx), ur.z - 0.002f)
+			v.vertex(positionMatrix, ur.x - (left * metersPerPixel), ur.y - (top * metersPerPixel), ur.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(0, 0)
 				.overlay(overlay)
 				.light(actualLight)
 				.normal(matrices.peek(), revNormal.x(), revNormal.y(), revNormal.z());
 
-			v.vertex(matrices.peek().getPositionMatrix(), dr.x - (offset.left() * xpx), dr.y + (offset.down() * ypx), dr.z - 0.002f)
+			v.vertex(positionMatrix, ur.x - (left * metersPerPixel), ur.y - (bottom * metersPerPixel), ur.z - 0.002f)
 				.color(0xFF_FFFFFF)
 				.texture(0, 1)
 				.overlay(overlay)

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/WShardPanel.java
@@ -24,7 +24,6 @@ import net.modfest.scatteredshards.api.ScatteredShardsAPI;
 import net.modfest.scatteredshards.api.ShardDisplaySettings;
 import net.modfest.scatteredshards.api.shard.Shard;
 import net.modfest.scatteredshards.api.shard.ShardIconOffsets;
-import net.modfest.scatteredshards.api.shard.ShardTextureSettings;
 import net.modfest.scatteredshards.api.shard.ShardType;
 import net.modfest.scatteredshards.client.screen.widget.scalable.WScaledLabel;
 import net.modfest.scatteredshards.client.screen.widget.scalable.WScaledText;
@@ -64,18 +63,37 @@ public class WShardPanel extends WPlainPanel {
 		.setShadow(true)
 		.setHorizontalAlignment(HorizontalAlignment.CENTER);
 
+	public void updateDimensionsAndBacking() {
+		if (shardType == null || shard == null) return;
+		
+		int cardScale = 2;
+		int halfLayoutWidth = this.getLayoutWidth() / 2;
+		int halfShardWidth = (int) (shardType.getTextureSettings().getSize().width() * cardScale) / 2;
+		
+		int cardX = this.insets.left() + (halfLayoutWidth - halfShardWidth); // Center the shard
+		int cardY = this.insets.top() + 40; // Arbitrary Y-offset to dodge text
+		
+		backing.setLocation(cardX, cardY);
+		backing.setImage(ShardType.getFrontTexture(shard.shardTypeId()));
+		backing.setSize((int) shardType.getTextureSettings().getSize().width() * cardScale, (int) shardType.getTextureSettings().getSize().height() * cardScale);
+		
+		ShardIconOffsets.Offset offset = this.shardType.getOffsets().getNormal();
+		
+		int iconX = cardX + (offset.left() * cardScale);
+		int iconY = cardY + (offset.up() * cardScale);
+		
+		icon.setLocation(iconX, iconY);
+		icon.setSize(16 * cardScale, 16 * cardScale);
+	}
+	
 	/**
 	 * Sets the shardType displayed to a static value. Note: Prevents the shardType from being updated if the configured shard is mutated!
 	 */
 	public WShardPanel setType(Identifier shardTypeId, ShardType value) {
 		this.shardType = value;
-
-		int cardScale = 2;
-		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
-		ShardIconOffsets.Offset offset = this.shardType.getOffsets().getNormal();
-		this.icon.setLocation(this.insets.left() + cardX + (offset.left() * cardScale), this.insets.top() + 40 + (offset.up() * cardScale));
-
-		backing.setImage(ShardType.getFrontTexture(shardTypeId));
+		
+		updateDimensionsAndBacking();
+		
 		typeDescription.setText(ShardType.getDescription(shardTypeId));
 		typeDescription.setColor(value::textColor);
 		return this;
@@ -128,10 +146,8 @@ public class WShardPanel extends WPlainPanel {
 		setSource(() -> Shard.getSourceForSourceId(shard.sourceId()), WHITE);
 		setLore(shard::lore, WHITE);
 		setHint(shard::hint, WHITE);
-
-		int cardScale = 2;
-		ShardTextureSettings.Size size = shardType.getTextureSettings().getSize();
-		backing.setSize((int)size.width() * cardScale, (int)size.height() * cardScale);
+		
+		updateDimensionsAndBacking();
 
 		return this;
 	}
@@ -163,12 +179,10 @@ public class WShardPanel extends WPlainPanel {
 
 		int cardScale = 2;
 		int cardX = ((this.getLayoutWidth()) / 2) - (12 * cardScale);
-
-		ShardTextureSettings.Size size = shardType.getTextureSettings().getSize();
-		add(backing, cardX, 40, (int)size.width() * cardScale, (int)size.height() * cardScale);
-
-		ShardIconOffsets.Offset offset = this.shardType.getOffsets().getNormal();
-		add(icon, cardX + (offset.left() * cardScale), 40 + (offset.up() * cardScale), 16 * cardScale, 16 * cardScale);
+		
+		add(backing, 0, 0, 32, 32);
+		
+		add(icon, 0, 0, 16, 16); //sizing set later in updateDimensionsAndBacking()
 
 
 		add(lore, 0, 113, getLayoutWidth(), 32);

--- a/src/main/java/net/modfest/scatteredshards/client/screen/widget/scalable/WScalableWidget.java
+++ b/src/main/java/net/modfest/scatteredshards/client/screen/widget/scalable/WScalableWidget.java
@@ -13,6 +13,7 @@ public abstract class WScalableWidget extends WWidget {
 	@Override
 	public void paint(DrawContext context, int x, int y, int mouseX, int mouseY) {
 		context.getMatrices().push();
+		
 		context.getMatrices().translate(x, y, 0);
 		context.getMatrices().scale(scale, scale, 1.0f);
 

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -4,13 +4,13 @@ license = "${license}"
 issueTrackerURL = "${issues}"
 
 [[mods]]
-modId = "${modId}"
+modId = "scattered_shards"
 version = "${version}"
 displayName = "${modName}"
 description = '''${modDescription}'''
 authors = "${members}"
 displayURL = "${homepage}"
-logoFile = "assets/${modId}/icon.png"
+logoFile = "assets/scattered_shards/icon.png"
 
 [properties]
 "connector:placeholder" = true

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,28 +15,28 @@ logoFile = "assets/scattered_shards/icon.png"
 [properties]
 "connector:placeholder" = true
 
-[[dependencies.${ modId }]]
+[[dependencies.scattered_shards]]
 modId = "connector"
 type = "required"
 versionRange = "*"
 ordering = "NONE"
 side = "BOTH"
 
-[[dependencies.${ modId }]]
+[[dependencies.scattered_shards]]
 modId = "neoforge"
 type = "required"
 versionRange = "*"
 ordering = "NONE"
 side = "BOTH"
 
-[[dependencies.${ modId }]]
+[[dependencies.scattered_shards]]
 modId = "minecraft"
 type = "required"
 versionRange = "[${mc},)"
 ordering = "NONE"
 side = "BOTH"
 
-[[dependencies.${ modId }]]
+[[dependencies.scattered_shards]]
 modId = "fabric_api"
 type = "required"
 versionRange = "[${fapi},)"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,11 +21,11 @@
 		"scattered_shards.mixins.json"
 	],
 	"depends": {
-		"minecraft": ">=${mc}",
-		"fabricloader": ">=${fl}",
-		"fabric-api": ">=${fapi}",
-		"libgui": ">=${libgui}",
-		"fabric-permissions-api-v0": ">=${fpapi}"
+		"minecraft": ">=1.21.1",
+		"fabricloader": ">=0.16.7",
+		"fabric-api": ">=0.104.0+1.21.1",
+		"libgui": ">=11.0.0+1.21",
+		"fabric-permissions-api-v0": ">=0.3.1"
 	},
 	"accessWidener": "scattered_shards.accesswidener",
 	"entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
-	"id": "${modId}",
+	"id": "scattered_shards",
 	"version": "${version}",
 	"name": "${modName}",
 	"description": "${modDescription}",
@@ -16,9 +16,9 @@
 		"sources": "${sources}"
 	},
 	"license": "${license}",
-	"icon": "assets/${modId}/icon.png",
+	"icon": "assets/scattered_shards/icon.png",
 	"mixins": [
-		"${modId}.mixins.json"
+		"scattered_shards.mixins.json"
 	],
 	"depends": {
 		"minecraft": ">=${mc}",
@@ -27,7 +27,7 @@
 		"libgui": ">=${libgui}",
 		"fabric-permissions-api-v0": ">=${fpapi}"
 	},
-	"accessWidener": "${modId}.accesswidener",
+	"accessWidener": "scattered_shards.accesswidener",
 	"entrypoints": {
 		"main": [
 			"net.modfest.scatteredshards.ScatteredShards"


### PR DESCRIPTION
- Fixes WShardPanel to display dimensions and offsets correctly
- Fixes ShardBlockEntityRenderer to display dimensions and offsets correctly
- Adds a PickBlock handler to ShardBlock
- Inlines templates just enough so that non-gradle builds can run.